### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Express/Connect middleware for managing authentication, backed by [PropelAuth
 
 ## Documentation
 
-- Full reference this library is [here](https://docs.propelauth.com/reference/frontend-apis/react.html)
+- Full reference this library is [here](https://docs.propelauth.com/reference/backend-apis/express/)
 - Getting started guides for PropelAuth are [here](https://docs.propelauth.com/)
 
 ## Questions?


### PR DESCRIPTION
The README contains a doc to the full reference for the library. There is a typo in the link, which points to the React library's docs rather than the Express library.