### PR TITLE
Added requireUserAndGetUserClass middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@propelauth/express",
-    "version": "2.1.18",
+    "version": "2.1.19",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@propelauth/express",
-            "version": "2.1.18",
+            "version": "2.1.19",
             "license": "MIT",
             "dependencies": {
                 "@propelauth/node": "^2.1.19"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // For backwards compatibility
-import { BaseAuthOptions, OrgMemberInfo, User } from "@propelauth/node"
+import { BaseAuthOptions, OrgMemberInfo, User, UserClass } from "@propelauth/node"
 
 export {
     AccessTokenCreationException,
@@ -83,6 +83,7 @@ declare global {
     namespace Express {
         interface Request {
             user?: User
+            userClass?: UserClass
             org?: OrgMemberInfo
         }
     }


### PR DESCRIPTION
Was working through the Express docs and noticed we require an extra step to create the user class. Made this change to automatically retrieve it. 

Instead of this:

```javascript
app.get("/api/whoami", requireUser, (req, res) => {
    const userClass = propelAuth.UserClass.fromUser(req.user);
    res.json("Hello user with ID " + userClass.userId);
});
``` 

We can now do this:

```javascript
app.get("/api/whoami", requireUser, (req, res) => {
    const userClass = req.userClass;
    res.json("Hello user with ID " + userClass.userId);
});
```