### PR TITLE
bump dependencies for legacy id features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@propelauth/express",
-    "version": "2.1.19",
+    "version": "2.1.23",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@propelauth/express",
-            "version": "2.1.19",
+            "version": "2.1.23",
             "license": "MIT",
             "dependencies": {
                 "@propelauth/node": "^2.1.19"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "user"
     ],
     "dependencies": {
-        "@propelauth/node": "^2.1.22"
+        "@propelauth/node": "^2.1.23"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/express"
     },
-    "version": "2.1.22",
+    "version": "2.1.23",
     "license": "MIT",
     "keywords": [
         "auth",


### PR DESCRIPTION
[upstream changes in node-apis](https://github.com/PropelAuth/node-apis/pull/22)