### PR TITLE
bump propelauth/node to 2.1.26, re-export types, pass thru new methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.1.23",
             "license": "MIT",
             "dependencies": {
-                "@propelauth/node": "^2.1.19"
+                "@propelauth/node": "^2.1.26"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^19.0.0",
@@ -993,18 +993,18 @@
             }
         },
         "node_modules/@propelauth/node": {
-            "version": "2.1.19",
-            "resolved": "https://registry.npmjs.org/@propelauth/node/-/node-2.1.19.tgz",
-            "integrity": "sha512-cH7vN9+/IKXOfjjbZ0/SPwOsqyoHpKVwXDAcfluGgSaAqAx8c1tXR3qVPW7E0hCKI++UavpubH59/6i73pdmXg==",
+            "version": "2.1.26",
+            "resolved": "https://registry.npmjs.org/@propelauth/node/-/node-2.1.26.tgz",
+            "integrity": "sha512-pkrZjAjSDXukd3YZVMuGMVfSGFxVbWYBPz/GbRF6pyOJVQ90YBcpqH+fXA7idCyRAyRCyE3VOlPpP7JL3n+bdQ==",
             "dependencies": {
-                "@propelauth/node-apis": "^2.1.19",
+                "@propelauth/node-apis": "^2.1.26",
                 "jose": "^5.2.0"
             }
         },
         "node_modules/@propelauth/node-apis": {
-            "version": "2.1.19",
-            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.19.tgz",
-            "integrity": "sha512-LDewv7ENy4QgRj9+dhu7cgudMi4vgSzwY9C7pkibErLtsuZJOPdIcbpNkI2rxSMyBBPcD8sXcu93mzO6MSdPTQ=="
+            "version": "2.1.26",
+            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.26.tgz",
+            "integrity": "sha512-jBKGBSBXRmaWBnqHQCXISm9IteDt82lsNx96roajpQgU9t1uFTfGH3J3gLTwXJT4S4pgxsrdaclf+Yr63IDSTg=="
         },
         "node_modules/@rollup/plugin-commonjs": {
             "version": "19.0.2",
@@ -6230,18 +6230,18 @@
             }
         },
         "@propelauth/node": {
-            "version": "2.1.19",
-            "resolved": "https://registry.npmjs.org/@propelauth/node/-/node-2.1.19.tgz",
-            "integrity": "sha512-cH7vN9+/IKXOfjjbZ0/SPwOsqyoHpKVwXDAcfluGgSaAqAx8c1tXR3qVPW7E0hCKI++UavpubH59/6i73pdmXg==",
+            "version": "2.1.26",
+            "resolved": "https://registry.npmjs.org/@propelauth/node/-/node-2.1.26.tgz",
+            "integrity": "sha512-pkrZjAjSDXukd3YZVMuGMVfSGFxVbWYBPz/GbRF6pyOJVQ90YBcpqH+fXA7idCyRAyRCyE3VOlPpP7JL3n+bdQ==",
             "requires": {
-                "@propelauth/node-apis": "^2.1.19",
+                "@propelauth/node-apis": "^2.1.26",
                 "jose": "^5.2.0"
             }
         },
         "@propelauth/node-apis": {
-            "version": "2.1.19",
-            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.19.tgz",
-            "integrity": "sha512-LDewv7ENy4QgRj9+dhu7cgudMi4vgSzwY9C7pkibErLtsuZJOPdIcbpNkI2rxSMyBBPcD8sXcu93mzO6MSdPTQ=="
+            "version": "2.1.26",
+            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.26.tgz",
+            "integrity": "sha512-jBKGBSBXRmaWBnqHQCXISm9IteDt82lsNx96roajpQgU9t1uFTfGH3J3gLTwXJT4S4pgxsrdaclf+Yr63IDSTg=="
         },
         "@rollup/plugin-commonjs": {
             "version": "19.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "user"
     ],
     "dependencies": {
-        "@propelauth/node": "^2.1.23"
+        "@propelauth/node": "^2.1.26"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/express"
     },
-    "version": "2.1.23",
+    "version": "2.1.24",
     "license": "MIT",
     "keywords": [
         "auth",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -111,7 +111,11 @@ export function initAuth(opts: AuthOptions) {
         validatePersonalApiKey: auth.validatePersonalApiKey,
         validateOrgApiKey: auth.validateOrgApiKey,
         fetchPendingInvites: auth.fetchPendingInvites,
-        revokePendingOrgInvite: auth.revokePendingOrgInvite
+        revokePendingOrgInvite: auth.revokePendingOrgInvite,
+        fetchSamlSpMetadata: auth.fetchSamlSpMetadata,
+        setSamlIdpMetadata: auth.setSamlIdpMetadata,
+        samlGoLive: auth.samlGoLive,
+        deleteSamlConnection: auth.deleteSamlConnection,
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,10 @@ export type {
     UsersInOrgQuery,
     UsersPagedResponse,
     UsersQuery,
+    RevokePendingOrgInviteRequest,
+    FetchSamlSpMetadataResponse,
+    SetSamlIdpMetadataRequest,
+    IdpProvider,
 } from "@propelauth/node"
 export { AuthOptions, initAuth } from "./auth"
 export type { RequireOrgMemberArgs } from "./auth"


### PR DESCRIPTION
Making features in upstream PRs ([org domain search](https://github.com/PropelAuth/node-apis/pull/25) and [saml setup](https://github.com/PropelAuth/node-apis/pull/24)) available.