### PR TITLE
re-export types for user-insights apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/express"
     },
-    "version": "2.1.34",
+    "version": "2.1.35",
     "license": "MIT",
     "keywords": [
         "auth",
@@ -12,7 +12,7 @@
         "user"
     ],
     "dependencies": {
-        "@propelauth/node": "^2.1.34"
+        "@propelauth/node": "^2.1.35"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,26 @@ export type {
     MfaTotpType,
     
 } from "@propelauth/node"
+export {
+    ReengagementReportInterval,
+    ChampionReportInterval,
+    ChurnReportInterval,
+    GrowthReportInterval,
+    AttritionReportInterval,
+    TopInviterReportInterval,
+    ChartMetric,
+    ChartMetricCadence,
+} from "@propelauth/node"
+export type {
+    ReportPagination,
+    UserReport,
+    UserReportRecord,
+    OrgReport,
+    OrgReportRecord,
+    UserOrgMembershipForReport,
+    ChartData,
+    ChartDataPoint,
+} from "@propelauth/node"
 export { AuthOptions, initAuth } from "./auth"
 export type { RequireOrgMemberArgs } from "./auth"
 export type { BaseAuthOptions, User, OrgMemberInfo }


### PR DESCRIPTION
Bumps `propelauth/node` dependancy to 2.1.35.
Bumps this package version to the same (2.1.35).
Depends on [this upstream PR](https://github.com/PropelAuth/node/pull/71)